### PR TITLE
node-sass version downgrade

### DIFF
--- a/03-currency-converter/01-Start/package.json
+++ b/03-currency-converter/01-Start/package.json
@@ -24,7 +24,7 @@
     "html-webpack-plugin": "2.26.0",
     "imports-loader": "0.7.1",
     "jquery": "3.2.1",
-    "node-sass": "4.4.0",
+    "node-sass": "4.13.0",
     "resolve-url-loader": "2.0.2",
     "rimraf": "2.6.1",
     "sass-loader": "4.1.1",


### PR DESCRIPTION
The devDependency "node-sass" : 4.4.0 fails to download. I fixed this by changing the version to 4.13.0